### PR TITLE
simplify a lot using fast-url-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
   },
   "repository": "expressjs/parseurl",
   "license": "MIT",
+  "dependencies": {
+    "fast-url-parser": "1.0.6-0"
+  },
   "devDependencies": {
     "benchmark": "1.0.0",
     "beautify-benchmark": "0.2.4",
-    "fast-url-parser": "~1.0.0",
     "mocha": "~1.20.0"
   },
   "scripts": {


### PR DESCRIPTION
okay this is the fastest i could get it. a lot of that shit ended up being unnecessary.

``` bash

  URL Parse Benchmark
  node version: v0.11.13, date: Tue Jul 15 2014 00:18:34 GMT-0700 (PDT)
  Starting...
  6 tests completed.

  url.parse(simpleurl)     x    79,291 ops/sec ±1.18% (96 runs sampled)
  url.parse(fullurl)       x    37,700 ops/sec ±0.81% (97 runs sampled)
  fasturl.parse(simpleurl) x 2,722,016 ops/sec ±0.75% (97 runs sampled)
  fasturl.parse(fullurl)   x 1,261,468 ops/sec ±0.40% (95 runs sampled)
  parseurl(simpleurl)      x 2,580,698 ops/sec ±0.34% (97 runs sampled)
  parseurl(fullurl)        x 1,245,875 ops/sec ±0.53% (99 runs sampled)
```

all this module does it do that `@` stuff ~_~ is it really worth it tho?
