### PR TITLE
fix potential RegExp DoS

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var Url = url.Url
  * See: https://github.com/joyent/node/pull/7878
  */
 
-var simplePathRegExp = /^(\/\/?(?!\/)[^?#\s]*)(\?[^#\s]*)?$/
+var simplePathRegExp = /^(\/\/?(?!\/)[^?#\s]*)(\?[^#\s]*$|$)/
 
 /**
  * Exports.


### PR DESCRIPTION
The provided `simplePathRegExp` has a star height greater 1 and is therefor
potentially vulnerable to ReDos.

```
require('safe-regex')(/^(\/\/?(?!\/)[^\?#\s]*)(\?[^#\s]*)?$/) === false

require('safe-regex')(/^(\/\/?(?!\/)[^\?#\s]*)(\?[^#\s]*$|$)/) === true
```

This PR changes the regex to have a star height = 1.
